### PR TITLE
Fix misspellings of "judgment"

### DIFF
--- a/src/032.txt
+++ b/src/032.txt
@@ -2,7 +2,7 @@ Rejoice in the Lord, O ye righteous; praise is meet for the upright.
 Confess unto the Lord with harp; with psaltery of ten strings make music unto him.
 Sing unto him a new song; sing well unto him with a joyful noise.
 For the word of the Lord is upright, and all his works are in faithfulness.
-The Lord loveth charity and judgement; the earth is full of the mercy of the Lord.
+The Lord loveth charity and judgment; the earth is full of the mercy of the Lord.
 By the word of the Lord were the heavens made firm, and all their power by the spirit of his mouth.
 He gathereth the waters of the sea together as in a wineskin; he layeth up the deeps in storehouses.
 Let all the earth fear the Lord; let all the inhabitants of the world be shaken before him.

--- a/src/081.txt
+++ b/src/081.txt
@@ -1,6 +1,6 @@
 God hath stood in an assembly of gods, and in the midst of them he judgeth gods.
 How long will ye judge unrighteousness, and persons of sinners recieve?
-Give judgement to poor and fatherless; do justice to humble and needy.
+Give judgment to poor and fatherless; do justice to humble and needy.
 Deliver poor and needy; from a hand of a sinner rescue them.
 They have not known, nor have they understood; in darkness they walk; let all the foundations of the earth be shaken.
 I have said, Ye are gods, and all of you are sons of the most High.

--- a/src/082.txt
+++ b/src/082.txt
@@ -1,6 +1,6 @@
 O God, who shall be likened unto thee? Keep not thy silence, neither be thou still, O God.
 For behold, thine enemies have roared, and they that hate thee have lifted up their head.
-Against thy people have they devised wicked judgement, and have taken counsel together against thy saints.
+Against thy people have they devised wicked judgment, and have taken counsel together against thy saints.
 They said, Come, let us utterly destroy them from being a nation, and the name of Israel shall be no more remembered.
 For they have consulted together in oneness of mind; they have made a covenant against thee;
 The tents of the Edomites, and the Ishmaelites,

--- a/src/111.txt
+++ b/src/111.txt
@@ -2,7 +2,7 @@ Blessed is the man that feareth the Lord; he shall greatly delight in his comman
 His seed shall be mighty upon the earth; a generation of upright shall be blessed.
 Glory and riches shall be in his house, and his righteousness endureth unto the age of the age.
 In darkness hath a light risen up for the upright; he is merciful and compassionate and righteous.
-Good is the man that showeth compassion and lendeth; he shall steward his words with judgement.
+Good is the man that showeth compassion and lendeth; he shall steward his words with judgment.
 For he shall not be moved unto the age; a righteous man shall be in everlasting remembrance.
 He shall not be afraid of evil tidings; ready is his heart to hope in the Lord.
 His heart is established, he shall not fear, until he looketh out upon his enemies.

--- a/src/147.txt
+++ b/src/147.txt
@@ -6,4 +6,4 @@ He giveth his snow like wool, and scattereth mist like ashes.
 He casteth forth his ice like morsels; who can stand before his cold?
 He shall send out his word, and melt them; his spirit shall blow, and the waters shall run.
 He declareth his word unto Jacob, his statutes and his judgments unto Israel.
-He hath not dealt so with every nation; and as for his judgements, he hath not revealed unto them.
+He hath not dealt so with every nation; and as for his judgments, he hath not revealed unto them.


### PR DESCRIPTION
Our spellings of "judgment" were inconsistent. We have 61 instances of "judgment" and 5 instances of "judgement".

```
032.txt:The Lord loveth charity and judgement; the earth is full of the mercy of the Lord.
081.txt:Give judgement to poor and fatherless; do justice to humble and needy.
082.txt:Against thy people have they devised wicked judgement, and have taken counsel together against thy saints.
111.txt:Good is the man that showeth compassion and lendeth; he shall steward his words with judgement.
147.txt:He hath not dealt so with every nation; and as for his judgements, he hath not revealed unto them.
```

Given that "majority rules" (🙂) and the original KJV uses "judgment", I've corrected the above 5 instances.