### PR TITLE
Replace period at end of verse 75:8 with comma

### DIFF
--- a/src/075.txt
+++ b/src/075.txt
@@ -5,7 +5,7 @@ Thou dost wonderfully shine forth from everlasting mountains.
 All the foolish of heart were troubled, they have slept their sleep, and all the men of wealth have found nothing in their hands.
 At thy rebuke, O God of Jacob, all they that mounted on horses slumbered.
 Thou art to be feared, and who shall stand against thee? Thenceforth is thy wrath.
-From out of the heaven didst thou cause judgment to be heard; earth feared, and was still.
+From out of the heaven didst thou cause judgment to be heard; earth feared, and was still,
 When God arose in judgment, to save all the meek of the earth.
 For the thought of man shall confess thee, and a remnant of thought shall keep feast unto thee.
 Make vows, and pay them unto the Lord our God; all those that are round about him shall bring gifts,


### PR DESCRIPTION
Verse 9 is a sentence fragment. It should be a continuation of verse 8.

Errant text:

> From out of the heaven didst thou cause judgment to be heard; earth feared, and was still.
> When God arose in judgment, to save all the meek of the earth.

Comparison to NETS:

> From the sky you made judgment heard; earth feared and was still,
when God rose up to establish judgment, to save all the meek of the earth.